### PR TITLE
fix redacted example

### DIFF
--- a/SwiftUI.swift
+++ b/SwiftUI.swift
@@ -33811,9 +33811,11 @@ extension Rectangle : InsettableShape {
 /// ```
 /// struct RedactedView: View {
 ///     var body: some View {
-///         Label("Taylor Swift", systemImage: "person.fill")
-///         Label("Kanye West", systemImage: "person.fill")
-///             .redacted(reason: .placeholder)
+///         VStack {
+///             Label("Taylor Swift", systemImage: "person.fill")
+///             Label("Kanye West", systemImage: "person.fill")
+///                 .redacted(reason: .placeholder)
+///         }
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
Hello, the current example of [RedactionReasons](https://swiftontap.com/redactionreasons) produces such a rendering:

<img width="1038" alt="Screenshot 2021-04-17 at 20 34 55" src="https://user-images.githubusercontent.com/7646025/115124386-3cf39400-9fc2-11eb-803e-3e7eca6e31e6.png">

I think adding a `VStack` would create the desired output. Or do you think it would be distracting?

<img width="598" alt="Screenshot 2021-04-17 at 20 35 46" src="https://user-images.githubusercontent.com/7646025/115124370-29482d80-9fc2-11eb-9ac6-22385bab1042.png">


I added a `VStack` in this PR, let me know what you think. 